### PR TITLE
allow read_can to reconnect on Siren connection failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
     let mut client = MqttClient::new(pub_path, "calypso-decoder");
     if client.connect().is_err() {
         println!("Unable to connect to Siren, going into reconnection mode.");
-        if let Ok(_) = client.reconnect() {
+        if client.reconnect().is_ok() {
             println!("Reconnected to Siren!");
         }
     }
@@ -61,7 +61,7 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
     thread::spawn(move || loop {
         if !client.is_connected() {
             println!("Unable to connect to Siren, going into reconnection mode.");
-            if let Ok(_) = client.reconnect() {
+            if client.reconnect().is_ok() {
                 println!("Reconnected to Siren!");
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,16 +165,24 @@ fn read_siren(pub_path: &str, send_map: Arc<RwLock<HashMap<u32, EncodeData>>>) -
             } else {
                 // the code doesnt work without this else statement
                 // idk why but never remove this else statement
-                let is_conn = client.is_connected();
-                println!("Client is {}", is_conn);
-                if !is_conn {
-                    println!("Trying to reconnect");
-                    match client.reconnect() {
-                        Ok(_) => println!("Reconnected!"),
-                        Err(_) => println!("Could not reconnect!"),
+                
+                while !client.is_connected() {
+                    println!("[read_siren] Unable to connect to Siren, going into reconnection mode.");
+                    if client.reconnect().is_ok() {
+                        println!("[read_siren] Reconnected to Siren!");
                     }
-                    continue;
                 }
+
+                // let is_conn = client.is_connected();
+                // println!("Client is {}", is_conn);
+                // if !is_conn {
+                //     println!("Trying to reconnect");
+                //     match client.reconnect() {
+                //         Ok(_) => println!("Reconnected!"),
+                //         Err(_) => println!("Could not reconnect!"),
+                //     }
+                //     continue;
+                // }
             }
         }
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,8 +115,8 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
  */
 fn read_siren(pub_path: &str, send_map: Arc<RwLock<HashMap<u32, EncodeData>>>) -> JoinHandle<()> {
     let mut client = MqttClient::new(pub_path, "calypso-encoder");
-    // client.connect().expect("Could not connect to Siren!");
-
+    
+    let _ = client.connect();
     while !client.is_connected() {
         println!("[read_siren] Unable to connect to Siren, going into reconnection mode.");
         if client.reconnect().is_ok() {
@@ -165,13 +165,17 @@ fn read_siren(pub_path: &str, send_map: Arc<RwLock<HashMap<u32, EncodeData>>>) -
             } else {
                 // the code doesnt work without this else statement
                 // idk why but never remove this else statement
-                
+
                 while !client.is_connected() {
                     println!("[read_siren] Unable to connect to Siren, going into reconnection mode.");
                     if client.reconnect().is_ok() {
+                        // TODO: consider resubscribing to the topics
                         println!("[read_siren] Reconnected to Siren!");
                     }
                 }
+                client
+                    .subscribe(ENCODER_MAP_SUB)
+                    .expect("Could not subscribe!");
 
                 // let is_conn = client.is_connected();
                 // println!("Client is {}", is_conn);

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,9 +60,9 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
     
     thread::spawn(move || loop {
         if !client.is_connected() {
-            println!("Unable to connect to Siren, going into reconnection mode.");
+            println!("[read_can] Unable to connect to Siren, going into reconnection mode.");
             if client.reconnect().is_ok() {
-                println!("Reconnected to Siren!");
+                println!("[read_can] Reconnected to Siren!");
             }
         }
 
@@ -101,7 +101,7 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
                         format!("failed to serialize {}", e).as_bytes().to_vec()
                     }),
                 ).is_err() {
-                println!("Failed to publish to Siren.");
+                println!("[read_can] Failed to publish to Siren.");
             }
 
             // TODO: investigate disabling this
@@ -115,7 +115,15 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
  */
 fn read_siren(pub_path: &str, send_map: Arc<RwLock<HashMap<u32, EncodeData>>>) -> JoinHandle<()> {
     let mut client = MqttClient::new(pub_path, "calypso-encoder");
-    client.connect().expect("Could not connect to Siren!");
+    // client.connect().expect("Could not connect to Siren!");
+
+    while !client.is_connected() {
+        println!("[read_siren] Unable to connect to Siren, going into reconnection mode.");
+        if client.reconnect().is_ok() {
+            println!("[read_siren] Reconnected to Siren!");
+        }
+    }
+
     let reciever = client.start_consumer().expect("Could not begin consuming");
     client
         .subscribe(ENCODER_MAP_SUB)


### PR DESCRIPTION
Modified the `read_can` function to improve resilience to connection failures. Instead of exiting on a connection failure with `.except()`, the function now attempts to reconnect, utilizing the `automatic_reconnect` interval options defined in `mqtt.rs`.

Tested to withstand disconnections to mosquitto service (on launch or in-session).