### PR TITLE
Add a way to simulate messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ decode_data.rs
 encode_data.rs
 encode_master_mapping.rs
 format_data.rs
+simulate_data.rs
 
 # my dumb script
 ./format

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ simulate_data.rs
 
 # my dumb script
 ./format
+/privatetest/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "paho-mqtt",
  "protobuf",
  "protobuf-codegen",
+ "rand",
  "socketcan",
 ]
 
@@ -362,6 +363,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +640,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -800,6 +851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,3 +933,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ protobuf-codegen = "3.5.1"
 protobuf = "3.5.1"
 bitstream-io = "2.5.3"
 clap = { version = "4.5.18", features = ["derive", "env"] }
+rand = "0.8"
 
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "calypso"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.79"
+default-run = "calypso"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Ex. `cansend vcan0 702#01010101FFFFFFFF`
 Now view calypso interpret the can message and broadcast it on `mqttui`
 
 
+### Simulation Mode
+- Same setup as above, then use the entry point `simulate` instead of `main`
+- ```cargo run --bin simulate```
+- ```cargo run --bin simulate  -- -u localhost:1883```
+
+
 
 ### Generate Proto
 

--- a/calypsogen.py
+++ b/calypsogen.py
@@ -23,6 +23,8 @@ decode_master_mapping = open("./src/decode_master_mapping.rs", "w")
 encode_data = open("./src/encode_data.rs", "w")
 encode_master_mapping = open("./src/encode_master_mapping.rs", "w")
 
+simulate_data = open("./src/simulate_data.rs", "w")
+
 format_data = open("./src/format_data.rs", "w")
 
 
@@ -55,6 +57,9 @@ encode_data.close()
 
 encode_master_mapping.write(result.encode_master_mapping)
 encode_master_mapping.close()
+
+simulate_data.write(result.simulate_data)
+simulate_data.close()
 
 format_data.write(result.format_data)
 format_data.close()

--- a/src/bin/simulate.rs
+++ b/src/bin/simulate.rs
@@ -7,23 +7,12 @@ use calypso::{
     mqtt::MqttClient, serverdata, simulatable_message::SimulatedComponents, simulate_data::create_simulated_components
 };
 use clap::Parser;
-// use protobuf::Message;
-// use socketcan::{CanError, CanFrame, CanSocket, EmbeddedFrame, Frame, Id, Socket, SocketOptions};
 
-// const ENCODER_MAP_SUB: &str = "Calypso/Bidir/Command/#";
 
 /// Calypso command line arguments
 #[derive(Parser, Debug)]
 #[command(version)]
 struct CalypsoArgs {
-    /// Whether to enable CAN message encoding
-    #[arg(short = 'e', long, env = "CALYPSO_CAN_ENCODE")]
-    encode: bool,
-
-    /// Whether to enable SIMULATION mode
-    #[arg(short = 's', long, env = "CALYPSO_CAN_SIMULATE")]
-    simulate: bool,
-
     /// The host url of the siren, including port and excluding protocol prefix
     #[arg(
         short = 'u',
@@ -32,15 +21,6 @@ struct CalypsoArgs {
         default_value = "localhost:1883"
     )]
     siren_host_url: String,
-
-    /// The SocketCAN interface port
-    #[arg(
-        short = 'c',
-        long,
-        env = "CALYPSO_SOCKETCAN_IFACE",
-        default_value = "vcan0"
-    )]
-    socketcan_iface: String,
 }
 
 
@@ -52,6 +32,7 @@ fn simulate_out(pub_path: &str) {
     // todo: a way to turn individual components on and off
     let mut simulated_components: Vec<SimulatedComponents> = create_simulated_components();
 
+    // loop through the simulated components, if they should update, update them and publish the data
     loop {
         for component in simulated_components.iter_mut() {
             if component.should_update() {
@@ -70,9 +51,9 @@ fn simulate_out(pub_path: &str) {
                     )
                     .expect("Could not publish!");
             }
-            // sleep for a bit
-            thread::sleep(sleep_time);
         }
+        // sleep for a bit
+        thread::sleep(sleep_time);
     }
 }
 
@@ -82,7 +63,6 @@ fn simulate_out(pub_path: &str) {
  * Main Function
  * Configures the can network, retrieves the client based on the command line arguments,
  * connects the client and then reads the can socket from specified interface.
- *
  */
 fn main() {
     let cli = CalypsoArgs::parse();

--- a/src/bin/simulate.rs
+++ b/src/bin/simulate.rs
@@ -1,0 +1,99 @@
+use std::{
+    thread::{self},
+    time::Duration,
+};
+
+use calypso::{
+    mqtt::MqttClient, serverdata, simulatable_message::SimulatedComponents, simulate_data::create_simulated_components
+};
+use clap::Parser;
+// use protobuf::Message;
+// use socketcan::{CanError, CanFrame, CanSocket, EmbeddedFrame, Frame, Id, Socket, SocketOptions};
+
+// const ENCODER_MAP_SUB: &str = "Calypso/Bidir/Command/#";
+
+/// Calypso command line arguments
+#[derive(Parser, Debug)]
+#[command(version)]
+struct CalypsoArgs {
+    /// Whether to enable CAN message encoding
+    #[arg(short = 'e', long, env = "CALYPSO_CAN_ENCODE")]
+    encode: bool,
+
+    /// Whether to enable SIMULATION mode
+    #[arg(short = 's', long, env = "CALYPSO_CAN_SIMULATE")]
+    simulate: bool,
+
+    /// The host url of the siren, including port and excluding protocol prefix
+    #[arg(
+        short = 'u',
+        long,
+        env = "CALYPSO_SIREN_HOST_URL",
+        default_value = "localhost:1883"
+    )]
+    siren_host_url: String,
+
+    /// The SocketCAN interface port
+    #[arg(
+        short = 'c',
+        long,
+        env = "CALYPSO_SOCKETCAN_IFACE",
+        default_value = "vcan0"
+    )]
+    socketcan_iface: String,
+}
+
+
+fn simulate_out(pub_path: &str) {
+    let mut client = MqttClient::new(pub_path, "calypso-simulator");
+    let _ = client.connect(); // todo: add error handling
+    let sleep_time = Duration::from_millis(10);
+
+    // todo: a way to turn individual components on and off
+    let mut simulated_components: Vec<SimulatedComponents> = create_simulated_components();
+
+    loop {
+        for component in simulated_components.iter_mut() {
+            if component.should_update() {
+                component.update();
+                let data: calypso::data::DecodeData = component.get_data();
+                let mut payload = serverdata::ServerData::new();
+                payload.unit = data.unit.to_string();
+                payload.value = data.value.iter().map(|x| x.to_string()).collect();
+
+                client
+                    .publish(
+                        data.topic.to_string(),
+                        protobuf::Message::write_to_bytes(&payload).unwrap_or_else(|e| {
+                            format!("failed to serialize {}", e).as_bytes().to_vec()
+                        }),
+                    )
+                    .expect("Could not publish!");
+            }
+            // sleep for a bit
+            thread::sleep(sleep_time);
+        }
+    }
+}
+
+
+
+/**
+ * Main Function
+ * Configures the can network, retrieves the client based on the command line arguments,
+ * connects the client and then reads the can socket from specified interface.
+ *
+ */
+fn main() {
+    let cli = CalypsoArgs::parse();
+    
+    // if cli.simulate {
+    //     println!("> Starting simulation mode");
+    simulate_out(&cli.siren_host_url);
+
+        // simulator_handle.join().expect("Simulator failed with ");
+        // return;
+    // }
+
+
+}

--- a/src/bin/simulate.rs
+++ b/src/bin/simulate.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use calypso::{
-    mqtt::MqttClient, serverdata, simulatable_message::SimulatedComponents, simulate_data::create_simulated_components
+    mqtt::MqttClient, serverdata, simulatable_message::SimulatedComponent, simulate_data::create_simulated_components
 };
 use clap::Parser;
 
@@ -30,7 +30,7 @@ fn simulate_out(pub_path: &str) {
     let sleep_time = Duration::from_millis(10);
 
     // todo: a way to turn individual components on and off
-    let mut simulated_components: Vec<SimulatedComponents> = create_simulated_components();
+    let mut simulated_components: Vec<SimulatedComponent> = create_simulated_components();
 
     // loop through the simulated components, if they should update, update them and publish the data
     loop {
@@ -61,19 +61,9 @@ fn simulate_out(pub_path: &str) {
 
 /**
  * Main Function
- * Configures the can network, retrieves the client based on the command line arguments,
- * connects the client and then reads the can socket from specified interface.
+ * Calls the `simulate_out` function with the siren host URL from the command line arguments.
  */
 fn main() {
     let cli = CalypsoArgs::parse();
-    
-    // if cli.simulate {
-    //     println!("> Starting simulation mode");
     simulate_out(&cli.siren_host_url);
-
-        // simulator_handle.join().expect("Simulator failed with ");
-        // return;
-    // }
-
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,5 @@ pub mod encode_master_mapping;
 pub mod format_data;
 pub mod mqtt;
 pub mod serverdata;
+pub mod simulate_data;
+pub mod simulatable_message;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use calypso::{
-    command_data, data::{DecodeData, EncodeData}, decodable_message::DecodableMessage, encodable_message::EncodableMessage, encode_master_mapping::ENCODABLE_KEY_LIST, mqtt::MqttClient, serverdata, simulatable_message::SimulatedComponents, simulate_data::create_simulated_components
+    command_data, data::DecodeData, data::EncodeData, decodable_message::DecodableMessage,
+    encodable_message::EncodableMessage, encode_master_mapping::ENCODABLE_KEY_LIST,
+    mqtt::MqttClient, serverdata,
 };
 use clap::Parser;
 use protobuf::Message;
@@ -21,10 +23,6 @@ struct CalypsoArgs {
     /// Whether to enable CAN message encoding
     #[arg(short = 'e', long, env = "CALYPSO_CAN_ENCODE")]
     encode: bool,
-
-    /// Whether to enable SIMULATION mode
-    #[arg(short = 's', long, env = "CALYPSO_CAN_SIMULATE")]
-    simulate: bool,
 
     /// The host url of the siren, including port and excluding protocol prefix
     #[arg(
@@ -147,40 +145,6 @@ fn read_can(pub_path: &str, can_interface: &str) -> JoinHandle<u32> {
     })
 }
 
-
-fn simulate_out(pub_path: &str) {
-    let mut client = MqttClient::new(pub_path, "calypso-simulator");
-    let _ = client.connect(); // todo: add error handling
-    let sleep_time = Duration::from_millis(10);
-
-    // todo: a way to turn individual components on and off
-    let mut simulated_components: Vec<SimulatedComponents> = create_simulated_components();
-
-    loop {
-        for component in simulated_components.iter_mut() {
-            if component.should_update() {
-                component.update();
-                let data: calypso::data::DecodeData = component.get_data();
-                let mut payload = serverdata::ServerData::new();
-                payload.unit = data.unit.to_string();
-                payload.value = data.value.iter().map(|x| x.to_string()).collect();
-
-                client
-                    .publish(
-                        data.topic.to_string(),
-                        protobuf::Message::write_to_bytes(&payload).unwrap_or_else(|e| {
-                            format!("failed to serialize {}", e).as_bytes().to_vec()
-                        }),
-                    )
-                    .expect("Could not publish!");
-            }
-            // sleep for a bit
-            thread::sleep(sleep_time);
-        }
-    }
-}
-
-
 /**
  * Reads the mqtt incoming messages and sends can messages based off of that
  */
@@ -300,16 +264,6 @@ fn send_out(
  */
 fn main() {
     let cli = CalypsoArgs::parse();
-    
-    if cli.simulate {
-        println!("> Starting simulation mode");
-        simulate_out(&cli.siren_host_url);
-
-        // simulator_handle.join().expect("Simulator failed with ");
-        return;
-    }
-
-
     let can_handle = read_can(&cli.siren_host_url, &cli.socketcan_iface);
 
     // use a arc for mutlithread, and a rwlock to enforce one writer

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -18,6 +18,7 @@ pub struct SimulatedComponent {
     sim_inc_max: f32,     // max increment step
     sim_freq: f32,        // Frequency in ms
     // format: String,       // e.g. "divide10"
+    #[allow(dead_code)]
     id: String,           // e.g. "0x80" (or should this be a uint32?)
     // signed: bool,         // is the value signed?
     // size: u8,            // size of the value in bits

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -60,9 +60,13 @@ impl SimulatedComponent {
 
         // initialize value with random values between sim_min and sim_max
 
-        // TODO: if size = 1, initialize with 0 or 1
         let mut rng = rand::thread_rng();
         for item in value.iter_mut().take(n_canpoints as usize) {
+            // handle boolean cases
+            if (sim_max - sim_min) == sim_inc_min || (sim_max - sim_min) == sim_inc_max {
+                *item = sim_min;
+                continue;
+            }
             *item = rng.gen_range(sim_min..sim_max);
         }
 
@@ -111,6 +115,7 @@ impl SimulatedComponent {
                 self.value[i] = new_value;
             }
     }
+
 
     pub fn get_data(&self) -> DecodeData {
         println!("[SimulatedComponents.get_data] Retrieving simulated data");

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -5,26 +5,38 @@ use std::time::Instant;
 /**
  * Wrapper class for an individual message.
  */
-pub struct SimulatedComponents {
-    pub value: Vec<f32>,      // DecodeData.value
-    pub topic: String,        // DecodeData.topic
-    pub unit: String,         // DecodeData.unit
-    pub last_update: Instant, // when the data was last updated
-    pub n_canpoints: u32,     // number of can points
-    pub sim_min: f32,         // min value
-    pub sim_max: f32,         // max value
-    pub sim_inc_min: f32,     // min increment step
-    pub sim_inc_max: f32,     // max increment step
-    pub sim_freq: f32,        // Frequency in ms
-    pub format: String,       // e.g. "divide10"
-    pub id: String,           // e.g. "0x80" (or should this be a uint32?)
-    pub signed: bool,         // is the value signed?
+pub struct SimulatedComponent {
+    value: Vec<f32>,      // DecodeData.value
+    topic: String,        // DecodeData.topic
+    unit: String,         // DecodeData.unit
+    last_update: Instant, // when the data was last updated
+    n_canpoints: u32,     // number of can points
+    sim_min: f32,         // min value
+    sim_max: f32,         // max value
+    sim_inc_min: f32,     // min increment step
+    sim_inc_max: f32,     // max increment step
+    sim_freq: f32,        // Frequency in ms
+    // format: String,       // e.g. "divide10"
+    id: String,           // e.g. "0x80" (or should this be a uint32?)
+    // signed: bool,         // is the value signed?
+    // size: u8,            // size of the value in bits
+}
+
+
+pub struct SimulatedComponentAttr {
+    pub sim_min: f32,
+    pub sim_max: f32,
+    pub sim_inc_min: f32,
+    pub sim_inc_max: f32,
+    pub sim_freq: f32,
+    pub n_canpoints: u32,
+    pub id: String,
 }
 
 /**
  * Implementation of SimulatedComponents.
  */
-impl SimulatedComponents {
+impl SimulatedComponent {
     pub fn should_update(&self) -> bool {
         self.last_update.elapsed().as_millis() > self.sim_freq as u128
     }
@@ -32,24 +44,26 @@ impl SimulatedComponents {
     pub fn new(
         topic: String,
         unit: String,
-        sim_min: f32,
-        sim_max: f32,
-        sim_inc_min: f32,
-        sim_inc_max: f32,
-        sim_freq: f32,
-        n_canpoints: u32,
-        format: String,
-        id: String,
-        signed: bool,
+        attr: SimulatedComponentAttr
     ) -> Self {
         println!("[SimulatedComponents.initialize] Initializing simulated components");
+            
+        let sim_min: f32 = attr.sim_min;
+        let sim_max: f32 = attr.sim_max;
+        let sim_inc_min: f32 = attr.sim_inc_min;
+        let sim_inc_max: f32 = attr.sim_inc_max;
+        let sim_freq: f32 = attr.sim_freq;
+        let n_canpoints: u32 = attr.n_canpoints;
+        let id: String = attr.id;
 
         let mut value = vec![0.0; n_canpoints as usize];
 
         // initialize value with random values between sim_min and sim_max
+
+        // TODO: if size = 1, initialize with 0 or 1
         let mut rng = rand::thread_rng();
-        for i in 0..n_canpoints as usize {
-            value[i] = rng.gen_range(sim_min..sim_max);
+        for item in value.iter_mut().take(n_canpoints as usize) {
+            *item = rng.gen_range(sim_min..sim_max);
         }
 
         Self {
@@ -63,15 +77,13 @@ impl SimulatedComponents {
             sim_inc_min,
             sim_inc_max,
             sim_freq,
-            format,
             id,
-            signed,
         }
     }
 
     pub fn update(&mut self) {
         println!("[SimulatedComponents.update] Updating simulated components");
-        println!("[SimulatedComponents.update] id: {}, format: {}, sim_min: {}, sim_max: {}, sim_inc_min: {}, sim_inc_max: {}, sim_freq: {}", self.id, self.format, self.sim_min, self.sim_max, self.sim_inc_min, self.sim_inc_max, self.sim_freq);
+        println!("[SimulatedComponents.update] id: {}, sim_min: {}, sim_max: {}, sim_inc_min: {}, sim_inc_max: {}, sim_freq: {}", self.id, self.sim_min, self.sim_max, self.sim_inc_min, self.sim_inc_max, self.sim_freq);
             self.last_update = Instant::now();
             let mut rng = rand::thread_rng();
             for i in 0..self.value.len() {

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -62,11 +62,6 @@ impl SimulatedComponent {
         // initialize value with random values between sim_min and sim_max
         let mut rng = rand::thread_rng();
         for item in value.iter_mut().take(n_canpoints as usize) {
-            // handle boolean cases
-            // if (sim_max - sim_min) == sim_inc_min || (sim_max - sim_min) == sim_inc_max {
-            //     *item = sim_min;
-            //     continue;
-            // }
             *item = (rng.gen_range(sim_min..sim_max) / sim_inc_min).round() * sim_inc_min;
         }
 
@@ -86,8 +81,8 @@ impl SimulatedComponent {
     }
 
     pub fn update(&mut self) {
-        println!("[SimulatedComponents.update] Updating simulated components");
-        println!("[SimulatedComponents.update] id: {}, sim_min: {}, sim_max: {}, sim_inc_min: {}, sim_inc_max: {}, sim_freq: {}", self.id, self.sim_min, self.sim_max, self.sim_inc_min, self.sim_inc_max, self.sim_freq);
+        // println!("[SimulatedComponents.update] Updating simulated components");
+        // println!("[SimulatedComponents.update] id: {}, sim_min: {}, sim_max: {}, sim_inc_min: {}, sim_inc_max: {}, sim_freq: {}", self.id, self.sim_min, self.sim_max, self.sim_inc_min, self.sim_inc_max, self.sim_freq);
             self.last_update = Instant::now();
             let mut rng = rand::thread_rng();
             for i in 0..self.value.len() {

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -13,8 +13,8 @@ pub struct SimulatedComponents {
     pub n_canpoints: u32,     // number of can points
     pub sim_min: f32,         // min value 
     pub sim_max: f32,         // max value
-    pub sim_inc_max: f32,     // max increment step
     pub sim_inc_min: f32,     // min increment step
+    pub sim_inc_max: f32,     // max increment step
     pub sim_freq: f32,        // Frequency in ms
     pub format: String,       // e.g. "divide10"
     pub id: String,           // e.g. "0x80" (or should this be a uint32?)
@@ -34,8 +34,8 @@ impl SimulatedComponents {
         unit: String, 
         sim_min: f32, 
         sim_max: f32, 
-        sim_inc_max: f32, 
         sim_inc_min: f32, 
+        sim_inc_max: f32, 
         sim_freq: f32,
         n_canpoints: u32,
         format: String,
@@ -60,8 +60,8 @@ impl SimulatedComponents {
             n_canpoints,
             sim_min,
             sim_max,
-            sim_inc_max,
             sim_inc_min,
+            sim_inc_max,
             sim_freq,
             format,
             id,

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -72,7 +72,6 @@ impl SimulatedComponents {
     pub fn update(&mut self) {
         println!("[SimulatedComponents.update] Updating simulated components");
         println!("[SimulatedComponents.update] id: {}, format: {}, sim_min: {}, sim_max: {}, sim_inc_min: {}, sim_inc_max: {}, sim_freq: {}", self.id, self.format, self.sim_min, self.sim_max, self.sim_inc_min, self.sim_inc_max, self.sim_freq);
-        if self.should_update() {
             self.last_update = Instant::now();
             let mut rng = rand::thread_rng();
             for i in 0..self.value.len() {
@@ -99,7 +98,6 @@ impl SimulatedComponents {
                 }
                 self.value[i] = new_value;
             }
-        }
     }
 
     pub fn get_data(&self) -> DecodeData {

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -1,0 +1,92 @@
+use std::time::Instant;
+use super::data::DecodeData;
+use rand::prelude::*;
+
+/**
+ * Wrapper class for an individual message.
+ */
+pub struct SimulatedComponents {
+    pub value: Vec<f32>,      // DecodeData.value
+    pub topic: String,        // DecodeData.topic
+    pub unit: String,         // DecodeData.unit
+    pub last_update: Instant, // when the data was last updated
+    pub n_canpoints: u32,     // number of can points
+    pub sim_min: f32,         // min value 
+    pub sim_max: f32,         // max value
+    pub sim_inc_max: f32,     // max increment step
+    pub sim_inc_min: f32,     // min increment step
+    pub sim_freq: f32,        // Frequency in ms
+    pub format: String,       // e.g. "divide10"
+    pub id: String,           // e.g. "0x80" (or should this be a uint32?)
+    pub signed: bool,         // is the value signed?
+}
+
+/**
+ * Implementation of SimulatedComponents.
+ */
+impl SimulatedComponents {
+    pub fn should_update(&self) -> bool {
+        self.last_update.elapsed().as_millis() > self.sim_freq as u128
+    }
+
+    pub fn new(
+        topic: String, 
+        unit: String, 
+        sim_min: f32, 
+        sim_max: f32, 
+        sim_inc_max: f32, 
+        sim_inc_min: f32, 
+        sim_freq: f32,
+        n_canpoints: u32,
+        format: String,
+        id: String,
+        signed: bool,
+    ) -> Self {
+        println!("[SimulatedComponents.initialize] Initializing simulated components");
+
+        let mut value = vec![0.0; n_canpoints as usize];
+        
+        // initialize value with random values between sim_min and sim_max
+        let mut rng = rand::thread_rng();
+        for i in 0..n_canpoints as usize {
+            value[i] = rng.gen_range(sim_min..sim_max);
+        }
+
+        Self {
+            value,
+            topic,
+            unit,
+            last_update: Instant::now(),
+            n_canpoints,
+            sim_min,
+            sim_max,
+            sim_inc_max,
+            sim_inc_min,
+            sim_freq,
+            format,
+            id,
+            signed,
+        }
+    }
+
+
+    pub fn update(&mut self) {
+        println!("[SimulatedComponents.update] Updating simulated components");
+        if self.should_update() {
+            self.last_update = Instant::now();
+            let mut rng = rand::thread_rng();
+            for i in 0..self.value.len() {
+                let rand_offset = rng.gen_range(self.sim_inc_min..self.sim_inc_max);
+                let sign = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
+                let new_value = self.value[i] + sign * rand_offset;
+                // TODO: add handling of exceeding sim_min and sim_max
+                self.value[i] = new_value;
+            }
+        }
+    }
+
+    pub fn get_data(&self) -> DecodeData {
+        println!("[SimulatedComponents.get_data] Retrieving simulated data");
+        DecodeData::new(self.value.clone(), &self.topic, &self.unit)
+    }
+}

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -1,6 +1,6 @@
-use std::time::Instant;
 use super::data::DecodeData;
 use rand::prelude::*;
+use std::time::Instant;
 
 /**
  * Wrapper class for an individual message.
@@ -11,7 +11,7 @@ pub struct SimulatedComponents {
     pub unit: String,         // DecodeData.unit
     pub last_update: Instant, // when the data was last updated
     pub n_canpoints: u32,     // number of can points
-    pub sim_min: f32,         // min value 
+    pub sim_min: f32,         // min value
     pub sim_max: f32,         // max value
     pub sim_inc_min: f32,     // min increment step
     pub sim_inc_max: f32,     // max increment step
@@ -30,12 +30,12 @@ impl SimulatedComponents {
     }
 
     pub fn new(
-        topic: String, 
-        unit: String, 
-        sim_min: f32, 
-        sim_max: f32, 
-        sim_inc_min: f32, 
-        sim_inc_max: f32, 
+        topic: String,
+        unit: String,
+        sim_min: f32,
+        sim_max: f32,
+        sim_inc_min: f32,
+        sim_inc_max: f32,
         sim_freq: f32,
         n_canpoints: u32,
         format: String,
@@ -45,7 +45,7 @@ impl SimulatedComponents {
         println!("[SimulatedComponents.initialize] Initializing simulated components");
 
         let mut value = vec![0.0; n_canpoints as usize];
-        
+
         // initialize value with random values between sim_min and sim_max
         let mut rng = rand::thread_rng();
         for i in 0..n_canpoints as usize {
@@ -69,17 +69,34 @@ impl SimulatedComponents {
         }
     }
 
-
     pub fn update(&mut self) {
         println!("[SimulatedComponents.update] Updating simulated components");
+        println!("[SimulatedComponents.update] id: {}, format: {}, sim_min: {}, sim_max: {}, sim_inc_min: {}, sim_inc_max: {}, sim_freq: {}", self.id, self.format, self.sim_min, self.sim_max, self.sim_inc_min, self.sim_inc_max, self.sim_freq);
         if self.should_update() {
             self.last_update = Instant::now();
             let mut rng = rand::thread_rng();
             for i in 0..self.value.len() {
-                let rand_offset = rng.gen_range(self.sim_inc_min..self.sim_inc_max);
+                let mut rand_offset: f32;
+
+                // handle the case where sim_inc_min == sim_inc_max
+                if self.sim_inc_min == self.sim_inc_max {
+                    rand_offset = self.sim_inc_min;
+                } else {
+                    rand_offset = rng.gen_range(self.sim_inc_min..self.sim_inc_max);
+                }
                 let sign = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
-                let new_value = self.value[i] + sign * rand_offset;
-                // TODO: add handling of exceeding sim_min and sim_max
+                
+                // getting a in-range new value
+                let mut new_value = self.value[i] + sign * rand_offset;
+                while new_value < self.sim_min || new_value > self.sim_max {
+                    if self.sim_inc_min == self.sim_inc_max {
+                        rand_offset = self.sim_inc_min;
+                    } else {
+                        rand_offset = rng.gen_range(self.sim_inc_min..self.sim_inc_max);
+                    }
+                    let sign = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
+                    new_value = self.value[i] + sign * rand_offset;
+                }
                 self.value[i] = new_value;
             }
         }

--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -10,6 +10,7 @@ pub struct SimulatedComponent {
     topic: String,        // DecodeData.topic
     unit: String,         // DecodeData.unit
     last_update: Instant, // when the data was last updated
+    #[allow(dead_code)]
     n_canpoints: u32,     // number of can points
     sim_min: f32,         // min value
     sim_max: f32,         // max value
@@ -46,7 +47,7 @@ impl SimulatedComponent {
         unit: String,
         attr: SimulatedComponentAttr
     ) -> Self {
-        println!("[SimulatedComponents.initialize] Initializing simulated components");
+        // println!("[SimulatedComponents.initialize] Initializing simulated components");
             
         let sim_min: f32 = attr.sim_min;
         let sim_max: f32 = attr.sim_max;
@@ -57,17 +58,16 @@ impl SimulatedComponent {
         let id: String = attr.id;
 
         let mut value = vec![0.0; n_canpoints as usize];
-
+        
         // initialize value with random values between sim_min and sim_max
-
         let mut rng = rand::thread_rng();
         for item in value.iter_mut().take(n_canpoints as usize) {
             // handle boolean cases
-            if (sim_max - sim_min) == sim_inc_min || (sim_max - sim_min) == sim_inc_max {
-                *item = sim_min;
-                continue;
-            }
-            *item = rng.gen_range(sim_min..sim_max);
+            // if (sim_max - sim_min) == sim_inc_min || (sim_max - sim_min) == sim_inc_max {
+            //     *item = sim_min;
+            //     continue;
+            // }
+            *item = (rng.gen_range(sim_min..sim_max) / sim_inc_min).round() * sim_inc_min;
         }
 
         Self {
@@ -98,6 +98,7 @@ impl SimulatedComponent {
                     rand_offset = self.sim_inc_min;
                 } else {
                     rand_offset = rng.gen_range(self.sim_inc_min..self.sim_inc_max);
+                    rand_offset = (rand_offset / self.sim_inc_min).round() * self.sim_inc_min;
                 }
                 let sign = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
                 
@@ -108,17 +109,17 @@ impl SimulatedComponent {
                         rand_offset = self.sim_inc_min;
                     } else {
                         rand_offset = rng.gen_range(self.sim_inc_min..self.sim_inc_max);
+                        rand_offset = (rand_offset / self.sim_inc_min).round() * self.sim_inc_min;
                     }
                     let sign = if rng.gen_bool(0.5) { 1.0 } else { -1.0 };
                     new_value = self.value[i] + sign * rand_offset;
                 }
-                self.value[i] = new_value;
+                self.value[i] = (new_value / self.sim_inc_min).round() * self.sim_inc_min;
             }
     }
 
 
     pub fn get_data(&self) -> DecodeData {
-        println!("[SimulatedComponents.get_data] Retrieving simulated data");
         DecodeData::new(self.value.clone(), &self.topic, &self.unit)
     }
 }


### PR DESCRIPTION
## Changes

- added entry point "simulate": `cargo run --bin simulate` (in `./src/bin/simulate.rs`)
- added calls to code generation for `simluate_data.rs`
- created new `SimulatedComponents` struct 

## To-do
- [x] Update README.md
- [x] handle failing case

## Known issues
- Due to `f32` limitations, large values with small increment steps will be stuck

## Future
- Multithreading for component update?

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)


Closes #49 
