### PR TITLE
Added support to decode IEEE754 32-bit floats over CAN

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Embedded-Base"]
 	path = Embedded-Base
 	url = ../Embedded-Base
+	branch = feature/can-spec-ieee754-f32

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "Embedded-Base"]
 	path = Embedded-Base
 	url = ../Embedded-Base
-	branch = feature/can-spec-ieee754-f32

--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -141,46 +141,51 @@ impl CANGenDecode for NetField {
  */
 impl CANGenDecode for CANPoint {
     fn gen_decoder_fn(&mut self) -> ProcMacro2TokenStream {
-        // read_func and read_type to map signedness (read_func for big endian, read_type for little endian)
         let size_literal = Literal::usize_unsuffixed(self.size);
-        let read_func = match self.signed {
-            Some(true) => quote! { reader.read_signed_in::<#size_literal, i32>().unwrap() },
-            _ => quote! { reader.read_in::<#size_literal, u32>().unwrap() },
-        };
-        let read_type = match self.signed {
-            Some(true) => match self.size {
-                0..=8 => quote! { i8 },
-                9..=16 => quote! { i16 },
-                _ => quote! { i32 },
-            },
-            _ => match self.size {
-                0..=8 => quote! { u8 },
-                9..=16 => quote! { u16 },
-                _ => quote! { u32 },
-            },
-        };
 
-        // prefix to call potential format function
+        // If this point is an IEEE754 f32, always read it as a u32, and transmute to f32 later
+        let read_type = match self.ieee754_f32 {
+            Some(true) => quote! { u32 },
+            _ => match self.signed {
+                Some(true) => match self.size {
+                    0..=8 => quote! { i8 },
+                    9..=16 => quote! { i16 },
+                    _ => quote! { i32 },
+                }
+                _ => match self.size {
+                    0..=8 => quote! { u8 },
+                    9..=16 => quote! { u16 },
+                    _ => quote! { u32 },
+                }
+            }
+        }; 
+
+        // Prefix to call potential format function
         let format_prefix = match &self.format {
             Some(format) => {
                 let id = format_ident!("{}_d", format);
                 quote! { FormatData::#id }
             }
-            _ => quote! {},
+            _ => quote! {}
         };
 
-        // Endianness affects which read to use
-        match self.endianness {
+        // Endianness and signedness affect which read to use
+        let read_func = match self.endianness {
             Some(ref s) if s == "little" => {
                 quote! {
-                    #format_prefix (reader.read_as_to::<LittleEndian, #read_type>().unwrap() as f32)
+                    reader.read_as_to::<LittleEndian, #read_type>().unwrap()
                 }
             }
-            _ => {
-                quote! {
-                    #format_prefix (#read_func as f32)
-                }
-            }
+            _ => match self.signed {
+                Some(true) if self.ieee754_f32 == None => quote! { reader.read_signed_in::<#size_literal, i32>().unwrap() },
+                _ => quote! { reader.read_in::<#size_literal, u32>().unwrap() },
+            } 
+        };
+
+        // Transmute if point is IEEE754 f32, else convert
+        match self.ieee754_f32 {
+            Some(true) => quote! { #format_prefix (f32::from_bits(#read_func)) },
+            _ =>  quote! { #format_prefix (#read_func as f32) },
         }
     }
 }

--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -177,7 +177,7 @@ impl CANGenDecode for CANPoint {
                 }
             }
             _ => match self.signed {
-                Some(true) if self.ieee754_f32 == None => {
+                Some(true) if self.ieee754_f32.is_none() => {
                     quote! { reader.read_signed_in::<#size_literal, i32>().unwrap() }
                 }
                 _ => quote! { reader.read_in::<#size_literal, u32>().unwrap() },

--- a/libs/calypso-cangen/src/can_gen_decode.rs
+++ b/libs/calypso-cangen/src/can_gen_decode.rs
@@ -151,14 +151,14 @@ impl CANGenDecode for CANPoint {
                     0..=8 => quote! { i8 },
                     9..=16 => quote! { i16 },
                     _ => quote! { i32 },
-                }
+                },
                 _ => match self.size {
                     0..=8 => quote! { u8 },
                     9..=16 => quote! { u16 },
                     _ => quote! { u32 },
-                }
-            }
-        }; 
+                },
+            },
+        };
 
         // Prefix to call potential format function
         let format_prefix = match &self.format {
@@ -166,7 +166,7 @@ impl CANGenDecode for CANPoint {
                 let id = format_ident!("{}_d", format);
                 quote! { FormatData::#id }
             }
-            _ => quote! {}
+            _ => quote! {},
         };
 
         // Endianness and signedness affect which read to use
@@ -177,15 +177,17 @@ impl CANGenDecode for CANPoint {
                 }
             }
             _ => match self.signed {
-                Some(true) if self.ieee754_f32 == None => quote! { reader.read_signed_in::<#size_literal, i32>().unwrap() },
+                Some(true) if self.ieee754_f32 == None => {
+                    quote! { reader.read_signed_in::<#size_literal, i32>().unwrap() }
+                }
                 _ => quote! { reader.read_in::<#size_literal, u32>().unwrap() },
-            } 
+            },
         };
 
         // Transmute if point is IEEE754 f32, else convert
         match self.ieee754_f32 {
             Some(true) => quote! { #format_prefix (f32::from_bits(#read_func)) },
-            _ =>  quote! { #format_prefix (#read_func as f32) },
+            _ => quote! { #format_prefix (#read_func as f32) },
         }
     }
 }

--- a/libs/calypso-cangen/src/can_types.rs
+++ b/libs/calypso-cangen/src/can_types.rs
@@ -3,6 +3,12 @@ use serde::Deserialize;
 // TODO: Implement MsgType
 
 /**
+ *  Classes to represent levels of the CAN hierarchy
+ *  For more specific descriptions, refer to the README
+ *  in Embedded-Base/cangen
+ */
+
+/**
  *  Class representing a CAN message
  */
 #[derive(Deserialize, Debug)]
@@ -38,6 +44,7 @@ pub struct CANPoint {
     pub endianness: Option<String>,
     pub format: Option<String>,
     pub default_value: Option<f32>,
+    pub ieee754_f32: Option<bool>, 
 }
 
 #[derive(Deserialize, Debug)]

--- a/libs/calypso-cangen/src/can_types.rs
+++ b/libs/calypso-cangen/src/can_types.rs
@@ -2,11 +2,9 @@ use serde::Deserialize;
 
 // TODO: Implement MsgType
 
-/**
- *  Classes to represent levels of the CAN hierarchy
- *  For more specific descriptions, refer to the README
- *  in Embedded-Base/cangen
- */
+// Classes to represent levels of the CAN hierarchy
+// For more specific descriptions, refer to the README
+// in Embedded-Base/cangen
 
 /**
  *  Class representing a CAN message

--- a/libs/calypso-cangen/src/can_types.rs
+++ b/libs/calypso-cangen/src/can_types.rs
@@ -44,7 +44,7 @@ pub struct CANPoint {
     pub endianness: Option<String>,
     pub format: Option<String>,
     pub default_value: Option<f32>,
-    pub ieee754_f32: Option<bool>, 
+    pub ieee754_f32: Option<bool>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
## Changes

- Calypso can now read the bits of a CANPoint as an IEEE754 32-bit float.
- To accommodate this, a new field has been added to the CAN spec. `ieee754_f32` is an optional boolean field in the CANPoint spec, which indicates that the CANPoint should be decoded as an `f32`.

## Notes

- CANPoints that wish to use this feature must specify the `ieee754_f32` field as `true` in the JSON.

## Test Cases

- Tested with @jr1221 

Closes #75
