### PR TITLE
Fix rate send of enums

### DIFF
--- a/src/simulatable_message.rs
+++ b/src/simulatable_message.rs
@@ -206,6 +206,7 @@ impl SimEnum {
 /// Base logic for enum sim
 impl SimShared for SimEnum {
     fn update(&mut self) {
+        self.component.last_update = Instant::now();
         let mut rng = rand::thread_rng();
         for i in 0..self.component.value.len() {
             let prob = rng.gen_range(0f32..1f32);


### PR DESCRIPTION
Before enums werent obey rate, and instead going all of the time.  Oops.  Now they are :)