### PR TITLE
Update dependabot.yml for Git Submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds git submodule checker to dependabot.  This will check Embedded-Base weekly to ensure it does not go out of date and cause confusion.